### PR TITLE
TabularDataSupport

### DIFF
--- a/src/main/resources/cjmx/help/format.md
+++ b/src/main/resources/cjmx/help/format.md
@@ -1,7 +1,7 @@
 
 Changes the output format of commands.
 
-    format text | json
+    format text | json | cjson
 
-Specifying text causes commands to output human readable text.  Specifying json causes commands to output JSON.  Default output format is text.
+Specifying text causes commands to output human readable text.  Specifying json causes commands to output JSON.  Specifying cjson causes commands to output a compact, but potentially backwards-incompatible JSON. Default output format is text.
 

--- a/src/main/scala/cjmx/cli/Parsers.scala
+++ b/src/main/scala/cjmx/cli/Parsers.scala
@@ -27,7 +27,7 @@ object Parsers {
     (token("help") ~> (' ' ~> any.+.string).?) map { topic => actions.Help(topic) }
 
   private lazy val SetFormat: Parser[Action] =
-    token("format ") ~> (("text" ^^^ TextMessageFormatter) | "json" ^^^ JsonMessageFormatter) map actions.SetFormat
+    token("format ") ~> (("text" ^^^ TextMessageFormatter) | "json" ^^^ JsonMessageFormatter.standard | "cjson" ^^^ JsonMessageFormatter.compact) map actions.SetFormat
 
   private lazy val Status: Parser[Action] =
     token("status") ^^^ actions.LastStatus


### PR DESCRIPTION
Adding TabularDataSupport for both text and json message formatters.

Introduced new 'format' of cjson (compact json)  TabularData is often Map<String, Object>.  When translating to JSON, I find it much more natural to treat TabularData of this form as a simple JSON object.  If the TabularData has multiple keys, then it needs to be translated as JSON array of JSON objects.

When in cjson, we perform the above optimization for simple tables.  When in regular json, we do not.

The reason we want to give the user the choice is because cjson won't be backwards-compatible if an TD started with one key and later added multiple.
