### PR TITLE
Modify to support Java 11 (remove agent jar loading)

### DIFF
--- a/src/main/scala/cjmx/util/jmx/Attach.scala
+++ b/src/main/scala/cjmx/util/jmx/Attach.scala
@@ -38,8 +38,7 @@ object Attach {
   def localConnectorAddress(vm: VirtualMachine): Either[String, String] = {
     def getLocalConnectorAddress = Option(vm.getAgentProperties.getProperty("com.sun.management.jmxremote.localConnectorAddress"))
     val localConnectorAddress = getLocalConnectorAddress orElse {
-      val agent = vm.getSystemProperties.getProperty("java.home") + File.separator + "lib" + File.separator + "management-agent.jar"
-      vm.loadAgent(agent)
+      vm.startLocalManagementAgent()
       getLocalConnectorAddress
     }
     localConnectorAddress.toRight("Failed to connect to VM ID %s.".format(vm.id))


### PR DESCRIPTION
Because java 11 removes most of the libs, and the existing code depended on loading the management-agent.jar, the current version failed to connect with a Java 11 instance. This change uses instead the VirtualMachine.startLocalManagementAgent() which was introduced in Java 8 and works in both Java 8 and Java 11.