### PR TITLE
Exclude tools.jar META-INF when producing -app.jar. 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ ProguardKeys.options in Proguard ++= Seq(ProguardOptions.keepMain("cjmx.Main"),
 ProguardKeys.inputFilter in Proguard := { file =>
   file.name match {
     case f if f startsWith "jansi-" => Some("!**")
+    case "tools.jar" => Some("!META-INF/**")
     case _ => Some("!META-INF/MANIFEST.MF")
   }
 }


### PR DESCRIPTION
This prevents errors from the service loader that cannot find implementations of the services in the jar.