### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,5 @@ For a more secure connection, it is recommended you run with SSL and/or with use
 
 cjmx will then prompt for the password.  To use SSL, you must run cjmx with the appropriate `javax.net.ssl` flags.
 
-For more details on configuring JMX agents, see: https://docs.oracle.com/javase/6/docs/technotes/guides/management/agent.html
+For more details on configuring JMX agents, see: https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ With this process running on host 'server', you can connect via cjmx using the '
 
 Once connected, cjmx supports all the same behaviors as with a local connection.
 
-For a more secure connection, it is recommended you run with SSL and/or with username authentication.  Usernames can be specified as the optional second paramter of the 'remote-connect' command:
+For a more secure connection, it is recommended you run with SSL and/or with username authentication.  Usernames can be specified as the optional second parameter of the 'remote-connect' command:
 
     cjmx remote-connect server:7091 admin
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Launching cjmx is done via, using Java 8+:
 
 If a PID is specified on the command line, cjmx will attempt to connect to the local JVM with that PID; otherwise, cjmx starts in a disconnected state.
 
-Once cjmx starts, a prompt will appear.  Cjmx makes heavy use of tab completion, enabling exploration of the MBean tree.  For example:
+Once cjmx starts, a prompt will appear.  cjmx makes heavy use of tab completion, enabling exploration of the MBean tree.  For example:
 
     java -jar path/to/cjmx.jar 1234
     > <TAB>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Getting cjmx
 
 cjmx is available on Maven Central using groupId `com.github.cjmx` and artifactId `cjmx_2.12`.  An executable JAR is published using the `app` classifier.
 
- - cjmx artifacts on Maven Central: https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.cjmx%22
+ - cjmx artifacts on Maven Central: https://search.maven.org/search?q=g:com.github.cjmx
  - Executable JAR using Scala 2.12: https://search.maven.org/remotecontent?filepath=com/github/cjmx/cjmx_2.12/2.8.1/cjmx_2.12-2.8.1-app.jar
 
 Note: Both a regular and an application JAR (with embedded dependencies and minimized) are published on Maven Central.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Getting cjmx
 
 cjmx is available on Maven Central using groupId `com.github.cjmx` and artifactId `cjmx_2.12`.  An executable JAR is published using the `app` classifier.
 
- - cjmx artifacts on Maven Central: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.cjmx%22
- - Executable JAR using Scala 2.12: http://search.maven.org/remotecontent?filepath=com/github/cjmx/cjmx_2.12/2.8.0/cjmx_2.12-2.8.0-app.jar
+ - cjmx artifacts on Maven Central: https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.cjmx%22
+ - Executable JAR using Scala 2.12: https://search.maven.org/remotecontent?filepath=com/github/cjmx/cjmx_2.12/2.8.0/cjmx_2.12-2.8.0-app.jar
 
 Note: Both a regular and an application JAR (with embedded dependencies and minimized) are published on Maven Central.
 
@@ -141,5 +141,5 @@ For a more secure connection, it is recommended you run with SSL and/or with use
 
 cjmx will then prompt for the password.  To use SSL, you must run cjmx with the appropriate `javax.net.ssl` flags.
 
-For more details on configuring JMX agents, see: http://docs.oracle.com/javase/6/docs/technotes/guides/management/agent.html
+For more details on configuring JMX agents, see: https://docs.oracle.com/javase/6/docs/technotes/guides/management/agent.html
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Getting cjmx
 cjmx is available on Maven Central using groupId `com.github.cjmx` and artifactId `cjmx_2.12`.  An executable JAR is published using the `app` classifier.
 
  - cjmx artifacts on Maven Central: https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.github.cjmx%22
- - Executable JAR using Scala 2.12: https://search.maven.org/remotecontent?filepath=com/github/cjmx/cjmx_2.12/2.8.0/cjmx_2.12-2.8.0-app.jar
+ - Executable JAR using Scala 2.12: https://search.maven.org/remotecontent?filepath=com/github/cjmx/cjmx_2.12/2.8.1/cjmx_2.12-2.8.1-app.jar
 
 Note: Both a regular and an application JAR (with embedded dependencies and minimized) are published on Maven Central.
 
@@ -22,7 +22,7 @@ Usage
 
 Launching cjmx is done via, using Java 8+:
 
-    java -cp $JAVA_HOME/lib/tools.jar:target/scala-2.12/proguard/cjmx_2.12-2.7.0-SNAPSHOT.jar cjmx.Main [PID]
+    java -cp $JAVA_HOME/lib/tools.jar:target/scala-2.12/proguard/cjmx_2.12-2.8.1-SNAPSHOT.jar cjmx.Main [PID]
 
 If a PID is specified on the command line, cjmx will attempt to connect to the local JVM with that PID; otherwise, cjmx starts in a disconnected state.
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ scalacOptions ++= Seq(
   "-target:jvm-1.8"
 )
 
-licenses += ("Three-clause BSD-style", url("http://github.com/cjmx/cjmx/blob/master/LICENSE"))
+licenses += ("Three-clause BSD-style", url("https://github.com/cjmx/cjmx/blob/master/LICENSE"))
 
 unmanagedResources in Compile ++= {
   val base = baseDirectory.value
@@ -99,7 +99,7 @@ publishArtifact in Test := false
 pomIncludeRepository := { x => false }
 
 pomExtra := (
-  <url>http://github.com/cjmx/cjmx</url>
+  <url>https://github.com/cjmx/cjmx</url>
   <scm>
     <url>git@github.com:cjmx/cjmx.git</url>
     <connection>scm:git:git@github.com:cjmx/cjmx.git</connection>
@@ -108,7 +108,7 @@ pomExtra := (
     <developer>
       <id>mpilquist</id>
       <name>Michael Pilquist</name>
-      <url>http://github.com/mpilquist</url>
+      <url>https://github.com/mpilquist</url>
     </developer>
   </developers>
 )

--- a/src/main/resources/cjmx/help/format.md
+++ b/src/main/resources/cjmx/help/format.md
@@ -3,5 +3,5 @@ Changes the output format of commands.
 
     format text | json | cjson
 
-Specifying text causes commands to output human readable text.  Specifying json causes commands to output JSON.  Specifying cjson causes commands to output a compact, but potentially backwards-incompatible JSON. Default output format is text.
+Specifying text causes commands to output human-readable text.  Specifying json causes commands to output JSON.  Specifying cjson causes commands to output a compact, but potentially backwards-incompatible JSON. Default output format is text.
 

--- a/src/main/resources/cjmx/help/help.md
+++ b/src/main/resources/cjmx/help/help.md
@@ -1,5 +1,5 @@
 
-Cjmx has two main states -- connected to a JVM and disconnected.  The commands available are sensitive to the current connectivity state.
+cjmx has two main states -- connected to a JVM and disconnected.  The commands available are sensitive to the current connectivity state.
 
 ## Global Commands
 

--- a/src/main/resources/cjmx/help/names.md
+++ b/src/main/resources/cjmx/help/names.md
@@ -4,7 +4,7 @@ Displays the names of all MBeans whose object names match the specified object n
     names ['object-name-pattern' [where query-expression]]
     mbeans 'object-name-pattern' [where query-expression] names
 
- - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
+ - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/8/docs/api/javax/management/ObjectName.html
  - query-expression - expression that limits the MBeans selected.  See "help query" for more information.
 
 Examples:

--- a/src/main/resources/cjmx/help/names.md
+++ b/src/main/resources/cjmx/help/names.md
@@ -4,7 +4,7 @@ Displays the names of all MBeans whose object names match the specified object n
     names ['object-name-pattern' [where query-expression]]
     mbeans 'object-name-pattern' [where query-expression] names
 
- - object-name-pattern - object name pattern conformant to pattern described in http://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
+ - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
  - query-expression - expression that limits the MBeans selected.  See "help query" for more information.
 
 Examples:

--- a/src/main/resources/cjmx/help/sample.md
+++ b/src/main/resources/cjmx/help/sample.md
@@ -4,7 +4,7 @@ Repeatedly gets attribute values of MBeans that match the specified object name 
     sample [* | projection] from 'object-name-pattern' [where query-expression] [every m seconds] [for n seconds]
     mbeans 'object-name-pattern' [where query-expression] sample [* | projection] [every m seconds] [for n seconds]
 
- - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
+ - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/8/docs/api/javax/management/ObjectName.html
  - query-expression - expression that limits the MBeans sampled.  See "help query" for more information.
  - projection - specification of the attribute values to sample.  Projections use the same format as those used in select.  See "help select" for more information.
  - m - number of seconds between samplings (defaults to 1).

--- a/src/main/resources/cjmx/help/sample.md
+++ b/src/main/resources/cjmx/help/sample.md
@@ -4,7 +4,7 @@ Repeatedly gets attribute values of MBeans that match the specified object name 
     sample [* | projection] from 'object-name-pattern' [where query-expression] [every m seconds] [for n seconds]
     mbeans 'object-name-pattern' [where query-expression] sample [* | projection] [every m seconds] [for n seconds]
 
- - object-name-pattern - object name pattern conformant to pattern described in http://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
+ - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
  - query-expression - expression that limits the MBeans sampled.  See "help query" for more information.
  - projection - specification of the attribute values to sample.  Projections use the same format as those used in select.  See "help select" for more information.
  - m - number of seconds between samplings (defaults to 1).

--- a/src/main/resources/cjmx/help/select.md
+++ b/src/main/resources/cjmx/help/select.md
@@ -4,7 +4,7 @@ Gets attribute values of MBeans that match the specified object name pattern and
     select [* | projection] from 'object-name-pattern' [where query-expression]
     mbeans 'object-name-pattern' [where query-expression] select [* | projection]
 
- - object-name-pattern - object name pattern conformant to pattern described in http://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
+ - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
  - query-expression - expression that limits the MBeans selected.  See "help query" for more information.
  - projection - specification of the attribute values to select.  Projections take the following form:
 

--- a/src/main/resources/cjmx/help/select.md
+++ b/src/main/resources/cjmx/help/select.md
@@ -4,7 +4,7 @@ Gets attribute values of MBeans that match the specified object name pattern and
     select [* | projection] from 'object-name-pattern' [where query-expression]
     mbeans 'object-name-pattern' [where query-expression] select [* | projection]
 
- - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html
+ - object-name-pattern - object name pattern conformant to pattern described in https://docs.oracle.com/javase/8/docs/api/javax/management/ObjectName.html
  - query-expression - expression that limits the MBeans selected.  See "help query" for more information.
  - projection - specification of the attribute values to select.  Projections take the following form:
 


### PR DESCRIPTION
I initially noticed the download link to the executable jar in the readme was not working and giving me the following error:
```
Mixed Content: The site at 'https://github.com/' was loaded over a secure connection, but the file at 'https://repo1.maven.org/maven2/com/github/cjmx/cjmx_2.12/2.8.0/cjmx_2.12-2.8.0-app.jar' was redirected through an insecure connection. This file should be served over HTTPS. This download has been blocked. See https://blog.chromium.org/2020/02/protecting-users-from-insecure.html for more details.
```
The link just needed upgrading to https, however I additionally cleanup the following:

- Upgraded all http links to https 
- There was a combination of version 2.7.0, 2.8.0 and 2.8.1 referenced in the docs. Bumped them all to 2.8.1.
- Cleaned up a search.maven.org URL
- Changed two instances of Cjmx to cjmx for consistency with the rest of the documentation. 
- Changed all javadoc links to point to Java 8 documentation (previously a mixture of 6 & 7) as cjmx requires Java 8+.
- Additional minor typo and grammar fixes.